### PR TITLE
Added canonical tags

### DIFF
--- a/components/ArticleContent.vue
+++ b/components/ArticleContent.vue
@@ -123,5 +123,13 @@ export default {
             }
         },
     },
+
+    head() {
+        return {
+            link: [
+                { rel: 'canonical', href: `https://get-better.me${this.document.path}/` },
+            ],
+        };
+    },
 };
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -56,6 +56,9 @@ export default {
     head() {
         return {
             title: 'Get Better',
+            link: [
+                { rel: 'canonical', href: 'https://get-better.me/' },
+            ],
         };
     },
 };


### PR DESCRIPTION
Added canonical tags based on the `document.path` and a trailing slash. The **index.vue** needs its own tag setup, as it is not based on a markdown file. 

Resolves romanzipp/GetBetter#3